### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ build the client. Binaries will be placed in `$GOPATH/bin`, if
 If you're into a one-off install, this
 
 ```bash
-go install -v github.com/m-lab/ndt7-client-go/cmd/ndt7-client
+go install -v github.com/m-lab/ndt7-client-go/cmd/ndt7-client@latest
 ```
 
 is equivalent to cloning the repository, running `go get ./cmd/ndt7-client`,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ build the client. Binaries will be placed in `$GOPATH/bin`, if
 If you're into a one-off install, this
 
 ```bash
-go get -v github.com/m-lab/ndt7-client-go/cmd/ndt7-client
+go install -v github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 ```
 
 is equivalent to cloning the repository, running `go get ./cmd/ndt7-client`,


### PR DESCRIPTION
go install is what you want to suggest users these days, not go get.

`For installing executables, [go get](https://go.dev/doc/go-get-install-deprecation)[ is deprecated since go 1.17](https://go.dev/doc/go-get-install-deprecation) and go install is the only viable option to acquire executables.`